### PR TITLE
Added configuration to test_sentinel to locate wallet dir

### DIFF
--- a/contrib/masternode/install_masternode.sh
+++ b/contrib/masternode/install_masternode.sh
@@ -185,6 +185,7 @@ pip install -r requirements.txt
 export EDITOR=nano
 (crontab -l -u masternode 2>/dev/null; echo '* * * * * cd /home/masternode/sentinel && ./venv/bin/python bin/sentinel.py >/dev/null 2>&1') | sudo crontab -u masternode -
 sudo chown -R masternode:masternode /home/masternode/sentinel
+echo "galactrum_conf=/home/masternode/.galactrum/galactrum.conf" | tee -a /home/masternode/sentinel/test/test_sentinel.conf
 cd ~
 
 # Add alias to run galactrum-cli


### PR DESCRIPTION
Previously, those who use the install script could not run the sentinel tests as it would look for the wallet folder in /root. This will ensure those who use the install script will be able to run the tests.